### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/notebook/agentchat_planning.ipynb
+++ b/notebook/agentchat_planning.ipynb
@@ -24,9 +24,9 @@
         "\n",
         "## Requirements\n",
         "\n",
-        "AutoGen requires `Python>=3.8`. To run this notebook example, please install pyautogen and docker:\n",
+        "AutoGen requires `Python>=3.8`. To run this notebook example, please install ag2 and docker:\n",
         "```bash\n",
-        "pip install pyautogen docker\n",
+        "pip install ag2 docker\n",
         "```"
       ]
     },
@@ -44,7 +44,7 @@
       },
       "outputs": [],
       "source": [
-        "# %pip install pyautogen~=0.1.0 docker"
+        "# %pip install ag2~=0.1.0 docker"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
